### PR TITLE
NetworkBinaryStream: fixed not decoding items with negative IDs corre…

### DIFF
--- a/src/pocketmine/network/mcpe/NetworkBinaryStream.php
+++ b/src/pocketmine/network/mcpe/NetworkBinaryStream.php
@@ -65,7 +65,7 @@ class NetworkBinaryStream extends BinaryStream{
 
 	public function getSlot() : Item{
 		$id = $this->getVarInt();
-		if($id <= 0){
+		if($id === 0){
 			return ItemFactory::get(0, 0, 0);
 		}
 


### PR DESCRIPTION
…ctly

negative IDs are used for new block-items.

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
