### PR TITLE
Server: Implemented an signal/sleep interrupt mechanism for ticking (…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,12 @@
       "ext-yaml": ">=2.0.0",
       "ext-zip": "*",
       "ext-zlib": ">=1.2.11",
-      "pocketmine/raklib": "dev-master#5de9f0dc4b076c454efdb075450737fe312d60ce",
+      "pocketmine/raklib": "dev-master#8a892d1b48142d091179ccd8abe64d11c6eede99",
       "pocketmine/spl": "0.3.0",
       "pocketmine/binaryutils": "dev-master#c824ac67eeeb6899c2a9ec91a769eb9ed6e3f595",
       "pocketmine/nbt": "dev-master#09809564c7e58c322dcefc6905ab333313e05d1f",
-      "pocketmine/math": "dev-master#bd78ce8ad1c0a583de6655eee46a82ccaade1302"
+      "pocketmine/math": "dev-master#bd78ce8ad1c0a583de6655eee46a82ccaade1302",
+      "pocketmine/snooze": "dev-master#96c740826df04024d2b685aa5ba8b8d0bdc69439"
    },
    "autoload": {
       "psr-4": {
@@ -53,6 +54,10 @@
       {
          "type": "vcs",
          "url": "https://github.com/pmmp/Math"
+      },
+      {
+         "type": "vcs",
+         "url": "https://github.com/pmmp/Snooze"
       }
    ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a9989451e8593a15cde64bf52466e4b",
+    "content-hash": "0f24757ea6a3627535e61e9bded163be",
     "packages": [
         {
             "name": "pocketmine/binaryutils",
@@ -120,12 +120,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/RakLib.git",
-                "reference": "5de9f0dc4b076c454efdb075450737fe312d60ce"
+                "reference": "8a892d1b48142d091179ccd8abe64d11c6eede99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/RakLib/zipball/5de9f0dc4b076c454efdb075450737fe312d60ce",
-                "reference": "5de9f0dc4b076c454efdb075450737fe312d60ce",
+                "url": "https://api.github.com/repos/pmmp/RakLib/zipball/8a892d1b48142d091179ccd8abe64d11c6eede99",
+                "reference": "8a892d1b48142d091179ccd8abe64d11c6eede99",
                 "shasum": ""
             },
             "require": {
@@ -136,6 +136,7 @@
                 "php-64bit": "*",
                 "php-ipv6": "*",
                 "pocketmine/binaryutils": "dev-master#c824ac67eeeb6899c2a9ec91a769eb9ed6e3f595",
+                "pocketmine/snooze": "dev-master#96c740826df04024d2b685aa5ba8b8d0bdc69439",
                 "pocketmine/spl": "0.3.0"
             },
             "type": "library",
@@ -152,7 +153,41 @@
                 "source": "https://github.com/pmmp/RakLib/tree/master",
                 "issues": "https://github.com/pmmp/RakLib/issues"
             },
-            "time": "2018-04-16T09:12:34+00:00"
+            "time": "2018-05-09T12:41:15+00:00"
+        },
+        {
+            "name": "pocketmine/snooze",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pmmp/Snooze.git",
+                "reference": "96c740826df04024d2b685aa5ba8b8d0bdc69439"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pmmp/Snooze/zipball/96c740826df04024d2b685aa5ba8b8d0bdc69439",
+                "reference": "96c740826df04024d2b685aa5ba8b8d0bdc69439",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pthreads": ">=3.1.7dev",
+                "php-64bit": ">=7.2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "pocketmine\\snooze\\": "src/"
+                }
+            },
+            "license": [
+                "LGPL-3.0"
+            ],
+            "description": "Thread notification management library for code using the pthreads extension",
+            "support": {
+                "source": "https://github.com/pmmp/Snooze/tree/master",
+                "issues": "https://github.com/pmmp/Snooze/issues"
+            },
+            "time": "2018-05-09T12:39:21+00:00"
         },
         {
             "name": "pocketmine/spl",
@@ -195,7 +230,8 @@
         "pocketmine/raklib": 20,
         "pocketmine/binaryutils": 20,
         "pocketmine/nbt": 20,
-        "pocketmine/math": 20
+        "pocketmine/math": 20,
+        "pocketmine/snooze": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/src/pocketmine/network/Network.php
+++ b/src/pocketmine/network/Network.php
@@ -85,20 +85,24 @@ class Network{
 
 	public function processInterfaces(){
 		foreach($this->interfaces as $interface){
-			try{
-				$interface->process();
-			}catch(\Throwable $e){
-				$logger = $this->server->getLogger();
-				if(\pocketmine\DEBUG > 1){
-					$logger->logException($e);
-				}
+			$this->processInterface($interface);
+		}
+	}
 
-				$this->server->getPluginManager()->callEvent(new NetworkInterfaceCrashEvent($interface, $e));
-
-				$interface->emergencyShutdown();
-				$this->unregisterInterface($interface);
-				$logger->critical($this->server->getLanguage()->translateString("pocketmine.server.networkError", [get_class($interface), $e->getMessage()]));
+	public function processInterface(SourceInterface $interface) : void{
+		try{
+			$interface->process();
+		}catch(\Throwable $e){
+			$logger = $this->server->getLogger();
+			if(\pocketmine\DEBUG > 1){
+				$logger->logException($e);
 			}
+
+			$this->server->getPluginManager()->callEvent(new NetworkInterfaceCrashEvent($interface, $e));
+
+			$interface->emergencyShutdown();
+			$this->unregisterInterface($interface);
+			$logger->critical($this->server->getLanguage()->translateString("pocketmine.server.networkError", [get_class($interface), $e->getMessage()]));
 		}
 	}
 


### PR DESCRIPTION
…#2171)

This allows other threads to notify the main thread to wake it up while it's sleeping between ticks, allowing reduction of processing latency.

Currently only RakLib and the CommandReader threads utilize this, but it's planned to extend it to more things in the near future.

CommandReader is now event-driven instead of poll-based - the server will not poll the CommandReader thread for messages each tick anymore.

RakLib utilizes this mechanism to get packets processed without delays to lower latency.

This now adds an extra dependency - `pocketmine/snooze` library contains the meat of the code used for this. See the Snooze repository for details.

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
